### PR TITLE
Remove TypedField.attr_name property.

### DIFF
--- a/mixbox/entities.py
+++ b/mixbox/entities.py
@@ -87,7 +87,7 @@ class Entity(object):
         for f in self.typed_fields:
             if not f.comparable:
                 continue
-            if getattr(self, f.attr_name) != getattr(other, f.attr_name):
+            if f.__get__(self) != f.__get__(other):
                 return False
 
         return True
@@ -185,8 +185,8 @@ class Entity(object):
                     val = [field.type_.from_obj(x) for x in val]
                 else:
                     val = field.type_.from_obj(val)
-            setattr(entity, field.attr_name, val)
 
+            field.__set__(entity, val)
         return entity
 
     @classmethod
@@ -221,7 +221,9 @@ class Entity(object):
             else:
                 if field.multiple and not val:
                     val = []
-            setattr(entity, field.attr_name, val)
+
+            # Set the value
+            field.__set__(entity, val)
 
         return entity
 

--- a/mixbox/fields.py
+++ b/mixbox/fields.py
@@ -47,7 +47,7 @@ class TypedField(object):
         self.preset_hook = preset_hook
         self.postset_hook = postset_hook
 
-    def __get__(self, instance, owner):
+    def __get__(self, instance, owner=None):
         # If we are calling this on a class, we want the actual Field, not its
         # value
         if not instance:
@@ -99,7 +99,7 @@ class TypedField(object):
             self.postset_hook(instance, value)
 
     def __str__(self):
-        return self.attr_name
+        return self.name
 
     @property
     def key_name(self):
@@ -107,26 +107,3 @@ class TypedField(object):
             return self._key_name
         else:
             return self.name.lower()
-
-    @property
-    def attr_name(self):
-        """The name of this field as an attribute name.
-
-        This is identical to the key_name, unless the key name conflicts with
-        a builtin Python keyword, in which case a single underscore is
-        appended.
-
-        This should match the name given to the TypedField class variable (see
-        examples below), but this is not enforced.
-
-        Examples:
-            data = cybox.TypedField("Data", String)
-            from_ = cybox.TypedField("From", String)
-        """
-
-        attr = self.key_name
-        # TODO: expand list with other Python keywords
-        if attr in ('from', 'class', 'type', 'with', 'for', 'id', 'type',
-                'range'):
-            attr = attr + "_"
-        return attr

--- a/tests/fields_tests.py
+++ b/tests/fields_tests.py
@@ -13,12 +13,10 @@ class TestTypedField(unittest.TestCase):
         a = TypedField("Some_Field", None)
         self.assertEqual("Some_Field", a.name)
         self.assertEqual("some_field", a.key_name)
-        self.assertEqual("some_field", a.attr_name)
 
         a = TypedField("From", None)
         self.assertEqual("From", a.name)
         self.assertEqual("from", a.key_name)
-        self.assertEqual("from_", a.attr_name)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This pull request removes the `attr_name` property from `TypedField`.  My biggest reason for doing this is that there have been issues in the past where the name generated from `attr_name` did not match the name of the class attribute to which the `TypedField` was assigned.

Example:
```python
class Foo(Entity):
    type = TypedField("Type")  # attr_name yields: "type_"
```

I don't think we really *need* `attr_name` , and it's a common area for issues so I figure we should toss it :) 

I made a [`remove-attr-name`](https://github.com/CybOXProject/python-cybox/compare/iter_typed_fields_cleanup...remove-attr-name) branch on python-cybox which includes the necessary changes to make the unit tests pass. 

**Disclaimer:** I may have completely overlooked something, so please @chisholm (and if possible @gtback) take a look and lemme know if I busted something.