### PR TITLE
Update supported Python versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,17 @@
 language: python
+python:
+  - 3.5
+
 env:
   - TOXENV=py26
   - TOXENV=py27
-  - TOXENV=py32
   - TOXENV=py33
   - TOXENV=py34
+  - TOXENV=py35
   - TOXENV=rhel6
 
 install:
-  - pip install tox
+  - pip install -U tox
 
 script:
   - tox

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ except ImportError:
 try:
     from weakref import WeakMethod
 except ImportError:
-    install_requires.append('weakrefmethod')
+    install_requires.append('weakrefmethod>=1.0.3')
 
 
 extras_require = {

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py26, py27, py32, py33, py34, rhel6
+envlist = py26, py27, py33, py34, py35, rhel6
 
 [testenv]
 commands =


### PR DESCRIPTION
Drop support for Python 3.2, add support for Python 3.5, and require a working version of a compatibility module for Python 3.3 and lower.

The PyPI version of weakrefmethod has been updated, so builds should work now.