### PR TITLE
Add a __hash__ function to the Entity class

### DIFF
--- a/mixbox/entities.py
+++ b/mixbox/entities.py
@@ -258,7 +258,21 @@ class Entity(object):
         return not self.__eq__(other)
 
     def __hash__(self):
-        return hash((g.__get__(self) for g in [f for f in self.typed_fields() if f.comparable]))
+        # Get all comparable TypedFields
+        typedfields = [f for f in self.typed_fields() if f.comparable]
+
+        fields = []
+        values = []
+        for field in typedfields:
+            value = field.__get__(self)
+            fields.append(field.key_name)
+            # Lists are unhashable, so convert them to tuples
+            if type(value) is list:
+                values.append(tuple(value))
+            else:
+                values.append(value)
+
+        return hash(tuple(fields + values))
 
     def to_obj(self, ns_info=None):
         """Convert to a GenerateDS binding object.

--- a/mixbox/entities.py
+++ b/mixbox/entities.py
@@ -257,6 +257,9 @@ class Entity(object):
     def __ne__(self, other):
         return not self.__eq__(other)
 
+    def __hash__(self):
+        return hash((g.__get__(self) for g in [f for f in self.typed_fields() if f.comparable]))
+
     def to_obj(self, ns_info=None):
         """Convert to a GenerateDS binding object.
 

--- a/tests/entities_tests.py
+++ b/tests/entities_tests.py
@@ -63,13 +63,22 @@ class TestEntity(unittest.TestCase):
 
 
     def test_equals_and_hash(self):
+
         class Mock(object):
             pass
+
         class SomeEntity(Entity):
             _binding_class = Mock
 
             single = fields.TypedField("Single")
             multiple = fields.TypedField("Multiple", multiple=True)
+
+        class AnotherEntity(Entity):
+            _binding_class = Mock
+
+            producer = fields.TypedField("Producer")
+            observable = fields.TypedField("Observable", multiple=True)
+
 
         s1 = SomeEntity()
         s1.single = "a"
@@ -83,6 +92,10 @@ class TestEntity(unittest.TestCase):
         s3.single = "a"
         s3.multiple = "a"
 
+        s4 = AnotherEntity()
+        s4.producer = "a"
+        s4.observable = "a"
+
         self.assertFalse(s1 is s3)
         self.assertEqual(s1, s3)
         self.assertEqual(hash(s1), hash(s3))
@@ -90,6 +103,10 @@ class TestEntity(unittest.TestCase):
         self.assertFalse(s1 is s2)
         self.assertNotEqual(s1, s2)
         self.assertNotEqual(hash(s1), hash(s2))
+
+        self.assertFalse(s1 is s4)
+        self.assertNotEqual(s1, s4)
+        self.assertNotEqual(hash(s1), hash(s4))
 
 
 class TestEntityList(unittest.TestCase):

--- a/tests/entities_tests.py
+++ b/tests/entities_tests.py
@@ -62,6 +62,36 @@ class TestEntity(unittest.TestCase):
         self.assertEqual(ecopy.bar, eorig.bar)
 
 
+    def test_equals_and_hash(self):
+        class Mock(object):
+            pass
+        class SomeEntity(Entity):
+            _binding_class = Mock
+
+            single = fields.TypedField("Single")
+            multiple = fields.TypedField("Multiple", multiple=True)
+
+        s1 = SomeEntity()
+        s1.single = "a"
+        s1.multiple = "a"
+
+        s2 = SomeEntity()
+        s2.single = "b"
+        s2.multiple = "b"
+
+        s3 = SomeEntity()
+        s3.single = "a"
+        s3.multiple = "a"
+
+        self.assertFalse(s1 is s3)
+        self.assertEqual(s1, s3)
+        self.assertEqual(hash(s1), hash(s3))
+
+        self.assertFalse(s1 is s2)
+        self.assertNotEqual(s1, s2)
+        self.assertNotEqual(hash(s1), hash(s2))
+
+
 class TestEntityList(unittest.TestCase):
 
     def test_remove(self):


### PR DESCRIPTION
This is to fix some "unhashable type" errors popping up in python-stix. For Python 3, "if [an object] defines \__eq__() but not \__hash__(), its instances will not be usable as items in hashable collections." [[1]](https://docs.python.org/3/reference/datamodel.html#object.__hash__)