### PR TITLE
Fix DateField and DateTimeField to use correct ISO format

### DIFF
--- a/mixbox/fields.py
+++ b/mixbox/fields.py
@@ -361,6 +361,9 @@ class DateTimeField(TypedField):
     def dict_value(self, value):
         return serialize_datetime(value)
 
+    def binding_value(self, value):
+        return serialize_datetime(value)
+
 
 class DateField(TypedField):
     def _clean(self, value):
@@ -368,6 +371,9 @@ class DateField(TypedField):
 
     def dict_value(self, value):
         return serialize_date(value)
+
+    def binding_value(self, value):
+        return serialize_datetime(value)
 
 
 class CDATAField(TypedField):


### PR DESCRIPTION
Once this is merged, we can release a new version of mixbox and fix the issue identified in STIXProject/python-stix#306.