### PR TITLE
Fix DateField serialization for datetime values. Fixes #34

### DIFF
--- a/mixbox/dates.py
+++ b/mixbox/dates.py
@@ -73,10 +73,10 @@ def serialize_date(value):
     """
     if not value:
         return None
-    elif isinstance(value, datetime.date):
-        return value.isoformat()
     elif isinstance(value, datetime.datetime):
         return value.date().isoformat()
+    elif isinstance(value, datetime.date):
+        return value.isoformat()
     else:
         return parse_date(value).isoformat()
 

--- a/mixbox/fields.py
+++ b/mixbox/fields.py
@@ -373,7 +373,7 @@ class DateField(TypedField):
         return serialize_date(value)
 
     def binding_value(self, value):
-        return serialize_datetime(value)
+        return serialize_date(value)
 
 
 class CDATAField(TypedField):

--- a/tests/dates_tests.py
+++ b/tests/dates_tests.py
@@ -15,6 +15,12 @@ class DatesTests(unittest.TestCase):
         dstr = "2015-04-01"
         parsed = dates.parse_date(dstr)
         self.assertEqual(dstr, parsed.isoformat())
+        
+    def test_serialize_datetime_as_date(self):
+        now = dates.now()
+        self.assertTrue(isinstance(now, datetime.datetime))
+        nowstr = dates.serialize_date(now)
+        self.assertEquals(nowstr, now.date().isoformat())
 
     def test_parse_datetime(self):
         dtstr = '2015-04-02T16:44:30.423149+00:00'


### PR DESCRIPTION
Fix #34 by having `DateField` properties serialize timestamp objects to `YYYY-MM-DD` date format instead of timestamp format.