### PR TITLE
Use assertEqual instead of assertEquals for Python 3.11 compatibility.

### DIFF
--- a/test/dates_tests.py
+++ b/test/dates_tests.py
@@ -20,7 +20,7 @@ class DatesTests(unittest.TestCase):
         now = dates.now()
         self.assertTrue(isinstance(now, datetime.datetime))
         nowstr = dates.serialize_date(now)
-        self.assertEquals(nowstr, now.date().isoformat())
+        self.assertEqual(nowstr, now.date().isoformat())
 
     def test_parse_datetime(self):
         dtstr = '2015-04-02T16:44:30.423149+00:00'

--- a/test/namespaces_tests.py
+++ b/test/namespaces_tests.py
@@ -114,12 +114,12 @@ class TestNamespaceSet(unittest.TestCase):
         self.assertEqual(ns.preferred_prefix_for_namespace("a:b:c"), "abc")
 
         ns.set_preferred_prefix_for_namespace("a:b:c", "def")
-        self.assertEquals(ns.preferred_prefix_for_namespace("a:b:c"), "def")
+        self.assertEqual(ns.preferred_prefix_for_namespace("a:b:c"), "def")
 
         ns.set_preferred_prefix_for_namespace("a:b:c", None)
 
         ns.set_preferred_prefix_for_namespace("a:b:c", "ghi", True)
-        self.assertEquals(ns.preferred_prefix_for_namespace("a:b:c"), "ghi")
+        self.assertEqual(ns.preferred_prefix_for_namespace("a:b:c"), "ghi")
 
         ns.add_prefix("a:b:c", "jkl", True)
         self.assertEqual(ns.preferred_prefix_for_namespace("a:b:c"), "jkl")


### PR DESCRIPTION
The deprecated aliases have been removed in python/cpython#28268