### PR TITLE
Replaced deprecated distutils.version.StrictVersion with packaging.version.Version

### DIFF
--- a/mixbox/parser.py
+++ b/mixbox/parser.py
@@ -2,7 +2,11 @@
 # See LICENSE.txt for complete terms.
 
 from abc import ABCMeta, abstractmethod
-from distutils.version import StrictVersion
+
+try:
+    from packaging.version import Version
+except ImportError:
+    from distutils.version import StrictVersion as Version
 
 from .exceptions import ignored
 from .xml import get_etree_root, get_etree, get_schemaloc_pairs
@@ -59,7 +63,7 @@ class EntityParser(object):
             root (etree.Element)
 
         Returns:
-            distutils.StrictVersion
+            packaging.version.Version
 
         Raises:
             UnknownVersionError
@@ -69,7 +73,7 @@ class EntityParser(object):
         # "cybox_minor_version", and "cybox_update_version".
         version = self.get_version(root)
         if version:
-            return StrictVersion(version)
+            return Version(version)
 
         raise UnknownVersionError(
             "Unable to determine the version of the input document. No "
@@ -86,7 +90,7 @@ class EntityParser(object):
             UnsupportedVersionError
         """
         version = self._get_version(root)
-        supported = [StrictVersion(x) for x in
+        supported = [Version(x) for x in
                      self.supported_versions(root.tag)]
 
         if version in supported:

--- a/mixbox/version.py
+++ b/mixbox/version.py
@@ -1,4 +1,4 @@
 # Copyright (c) 2015, The MITRE Corporation. All rights reserved.
 # See LICENSE.txt for complete terms.
 
-__version__ = "1.0.5"
+__version__ = "1.0.6"

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.0.5
+current_version = 1.0.6
 tag = True
 commit = True
 

--- a/setup.py
+++ b/setup.py
@@ -74,5 +74,7 @@ setup(
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
+        'Programming Language :: Python :: 3.9',
+        'Programming Language :: Python :: 3.10',
     ]
 )

--- a/setup.py
+++ b/setup.py
@@ -76,5 +76,7 @@ setup(
         'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',
         'Programming Language :: Python :: 3.10',
+        'Programming Language :: Python :: 3.11',
+        'Programming Language :: Python :: 3.12',
     ]
 )

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py26, py27, py35, py36, py37, py38, py39, py310, rhel6
+envlist = py26, py27, py35, py36, py37, py38, py39, py310, py311, py312, rhel6, rhel7, rhel8
 
 [testenv]
 commands =
@@ -27,3 +27,5 @@ python =
   3.8: py38
   3.9: py39
   3.10: py310
+  3.11: py311
+  3.12: py312

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py26, py27, py35, py36, py37, py38, rhel6
+envlist = py26, py27, py35, py36, py37, py38, py39, py310, rhel6
 
 [testenv]
 commands =
@@ -25,3 +25,5 @@ python =
   3.6: py36
   3.7: py37
   3.8: py38
+  3.9: py39
+  3.10: py310


### PR DESCRIPTION
The package does not install in Python 3.12 because distutils.version.StrictVersion is deprecated (https://github.com/pypa/packaging/issues/520)